### PR TITLE
Need to do static linking for atlas and cblas

### DIFF
--- a/Makeheader
+++ b/Makeheader
@@ -18,9 +18,14 @@ GRAMMAR     = grammar
 OPT         = -O2
 DEBUG       =
 PURIFY      =
+
 #Marit/Alf: Dette virker ikke under Ubuntu
-#ATLASLFLAGS = -L/lib64 -lgfortran -lpthread -Wl,/usr/lib64/atlas/liblapack.a,/usr/lib64/libblas.a,/usr/lib64/atlas/libcblas.a,/usr/lib64/atlas/libatlas.a
-ATLASLFLAGS = -L/usr/lib64/atlas -L/usr/lib64/atlas/atlas -L/lib64 -llapack -lblas -lcblas -latlas -lgfortran -lpthread
+#Da må vi prøve å fikse det for ubuntu med statisk linking. Tester denne på ubuntu når jeg får tid.
+ATLASLFLAGS = -L/lib64 -lgfortran -lpthread -Wl,/usr/lib64/atlas/liblapack.a,/usr/lib64/libblas.a,/usr/lib64/atlas/libcblas.a,/usr/lib64/atlas/libatlas.a
+
+# Dynamic linking of all libraries, does not work on standard RHEL5 due to missing cblas and atlas
+#ATLASLFLAGS = -L/usr/lib64/atlas -L/usr/lib64/atlas/atlas -L/lib64 -llapack -lblas -lcblas -latlas -lgfortran -lpthread
+
 mode        = all
 
 ifeq ($(GCCNEW),1)


### PR DESCRIPTION
Atlas and cblas are not included on Red Hat, they need to be statically linked for user convenience. I understand that we need this to work on ubuntu too, but I will need more time to investigate what issues may arise there.
