### PR TITLE
CRA-659: Removed -Wold-style-cast from Makeheader to make CRAVA compile with old gcc (troll).

### DIFF
--- a/Makeheader
+++ b/Makeheader
@@ -12,7 +12,7 @@ GCCWARNING := -Wall -pedantic -Wno-long-long -Werror
 # segy/traceheader.cpp: In member function ‘int NRLib::TraceHeader::GetInt32(int) const’:
 # segy/traceheader.cpp:519: error: dereferencing type-punned pointer will break strict-aliasing rules
 #
-GXXWARNING  = -Wall -pedantic -Woverloaded-virtual -Wno-long-long -Wold-style-cast -Werror -fno-strict-aliasing
+GXXWARNING  = -Wall -pedantic -Woverloaded-virtual -Wno-long-long -Werror -fno-strict-aliasing
 PROGRAM     = cravarun
 GRAMMAR     = grammar
 OPT         = -O2


### PR DESCRIPTION
...with old gcc (troll).
