### PR TITLE
CRA-683: Fixed the problem with dz not set, and at the same time removed...

### DIFF
--- a/src/modelavodynamic.cpp
+++ b/src/modelavodynamic.cpp
@@ -661,7 +661,8 @@ ModelAVODynamic::ModelAVODynamic(ModelSettings          *& model_settings,
         //Find the scaling of this wavelet, and apply it to the non-resampled wavelet.
         Wavelet * est_wavelet = new Wavelet1D(wavelets_[i]);
         const Simbox & estimation_simbox = common_data->GetEstimationSimbox();
-        est_wavelet->resample(static_cast<float>(estimation_simbox.getdz()), estimation_simbox.getnz(), estimation_simbox.GetNZpad());
+        if(est_wavelet->getInFFTOrder() == false) //Indicates wavelet read from file; true would mean estimated wavelet, which has correct resolution.
+          est_wavelet->resample(static_cast<float>(estimation_simbox.getdz()), estimation_simbox.getnz(), estimation_simbox.GetNZpad());
         est_wavelet->scale(1.0);
         std::vector<std::vector<double> > seis_logs(orig_blocked_logs.size());
         int w = 0;

--- a/src/seismicstorage.cpp
+++ b/src/seismicstorage.cpp
@@ -340,6 +340,8 @@ SeismicStorage::FindSimbox(const Simbox & full_inversion_simbox,
                              static_cast<int>(storm_grid_->GetNI()),
                              static_cast<int>(storm_grid_->GetNJ()),
                              err_txt);
+      seismic_simbox.setDepth(storm_grid_->GetTopSurface(), storm_grid_->GetBotSurface(), storm_grid_->GetNK(), true);
+      seismic_simbox.calculateDz(lz_limit, err_txt);
       seismic_simbox.SetNoPadding();
       break;
     default:

--- a/src/wavelet.h
+++ b/src/wavelet.h
@@ -159,15 +159,15 @@ public:
                                  bool                                       /*estimateSNRatio*/,
                                  bool                                       /*estimateWavelet*/) {return 1.0f;}
 
- float          findNormWithinFrequencyBand(float loCut ,float hiCut ) const;
- void           nullOutsideFrequencyBand(float loCut ,float hiCut );
- float          findNorm() const;
- void           SetReflectionCoeffs(const float * reflCoef);
+  float          findNormWithinFrequencyBand(float loCut ,float hiCut ) const;
+  void           nullOutsideFrequencyBand(float loCut ,float hiCut );
+  float          findNorm() const;
+  void           SetReflectionCoeffs(const float * reflCoef);
+  bool           getInFFTOrder()     const {return inFFTorder_;}
 
 protected:
   float          getTheta()          const {return theta_;}
   int            getCz()             const {return cz_;}
-  bool           getInFFTOrder()     const {return inFFTorder_;}
   float          getWaveletLength()  const {return waveletLength_;}
 
   void           doLocalShiftAndScale1D(Wavelet1D* localWavelet,// wavelet to shift and scale


### PR DESCRIPTION
... bug where ModelAVODynamic crashed when wavelet was from file.

Note that this does not solve the problem in CRA-683, as there still is a scaling issue between wells and seismic data. (Location of seismic data is given in km, wells in m)
