### PR TITLE
CRA-858 Fixed issue with segy dz

### DIFF
--- a/doc/user_manual/4_referencemanual.tex
+++ b/doc/user_manual/4_referencemanual.tex
@@ -1525,7 +1525,7 @@ the vertical sampling interval we find the the number of parameters that is esti
  \slist
    \item \Description Should global scale be estimated?
    \item \Argument 'yes' or 'no'
-   \item \Default
+   \item \Default 'yes' Ricker wavelets, and 'no' for wavelets read from file.
  \elist
 
 \paragraph{\hbracket{local-wavelet}}\newkw{local-wavelet}

--- a/libs/nrlib/segy/segy.cpp
+++ b/libs/nrlib/segy/segy.cpp
@@ -322,6 +322,7 @@ SegY::SegY(const std::string       & fileName,
 SegY::SegY(const StormContGrid     * storm_grid,
            const SegyGeometry      * geometry,
            float                     z0,
+           float                     dz,
            int                       nz,
            const std::string       & file_name,
            bool                      write_to_file,
@@ -337,7 +338,6 @@ SegY::SegY(const StormContGrid     * storm_grid,
   TextualHeader header = TextualHeader::standardHeader();
   int nx = static_cast<int>(storm_grid->GetNI());
   int ny = static_cast<int>(storm_grid->GetNJ());
-  float dz = floor((storm_grid->GetZMax() - z0)/static_cast<float>(nz)+0.5);
 
   trace_header_format_ = trace_header_format;
   z0_ = z0;

--- a/libs/nrlib/segy/segy.hpp
+++ b/libs/nrlib/segy/segy.hpp
@@ -82,6 +82,7 @@ public:
  SegY(const StormContGrid     * storm_grid,
       const SegyGeometry      * geometry, //May be set to 0.
       float                     z0,
+      float                     dz,
       int                       nz,
       const std::string       & file_name = "",
       bool                      write_to_file = true,

--- a/src/blockedlogscommon.cpp
+++ b/src/blockedlogscommon.cpp
@@ -2916,7 +2916,6 @@ void  BlockedLogsCommon::SetLogFromVerticalTrend(const std::vector<double>      
                                                  std::string                                    type,
                                                  int                                            i_angle) const
 {
-  //n_angles_ = n_angles;
 
   if (type != "WELL_SYNTHETIC_SEISMIC")
   {
@@ -3617,7 +3616,7 @@ void BlockedLogsCommon::GenerateSyntheticSeismic(const NRLib::Matrix        & re
   fftw_real    * synt_seis_r = new fftw_real[rnzp];
   fftw_complex * synt_seis_c = reinterpret_cast<fftw_complex*>(synt_seis_r);
 
-  GetVerticalTrend(GetVpBlocked(), vp_vert); //alpha_
+  GetVerticalTrend(GetVpBlocked(), vp_vert);
   GetVerticalTrend(GetVsBlocked(), vs_vert);
   GetVerticalTrend(GetRhoBlocked(), rho_vert);
 

--- a/src/commondata.cpp
+++ b/src/commondata.cpp
@@ -4347,7 +4347,8 @@ void CommonData::SetSurfaces(const ModelSettings * const model_settings,
         if (model_settings->getParallelTimeSurfaces() == true) { //Only one reference surface
           double d_top = model_settings->getTimeDTop();
           double lz    = model_settings->getTimeLz();
-          top_surface->Add(d_top);
+          if (d_top != RMISSING)
+            top_surface->Add(d_top);
           base_surface = new Surface(*top_surface);
           base_surface->Add(lz);
           LogKit::LogFormatted(LogKit::Low,"Base surface: parallel to the top surface, shifted %11.2f down.\n", lz);
@@ -4532,8 +4533,13 @@ bool CommonData::BlockWellsForEstimation(const ModelSettings                    
       BlockedLogsCommon * blocked_log = new BlockedLogsCommon(wells[i], continuous_logs_to_be_blocked, discrete_logs_to_be_blocked,
                                                               &estimation_simbox, model_settings->getRunFromPanel(), false, is_inside, err_text);
 
-      if (is_inside == false)
-        err_text += "Well "+wells[i]->GetWellName()+" was not found within the estimation simbox surrounding the inversion intervals.\n";
+      if (is_inside == false) {
+        LogKit::LogFormatted(LogKit::Low,"\n Well "+wells[i]->GetWellName()+" was not found within the simbox.\n");
+        if (est_simbox)
+          err_text += "Well "+wells[i]->GetWellName()+" was not found within the estimation simbox.\n";
+        else
+          err_text += "Well "+wells[i]->GetWellName()+" was not found within the output simbox.\n";
+      }
 
       mapped_blocked_logs_common.insert(std::pair<std::string, BlockedLogsCommon *>(wells[i]->GetWellName(), blocked_log));
 
@@ -10122,7 +10128,8 @@ void CommonData::PrintSettings(const ModelSettings    * model_settings,
   if (model_settings->getParallelTimeSurfaces())
   {
     LogKit::LogFormatted(LogKit::Low,"  Reference surface                        : "+input_files->getTimeSurfTopFile()+"\n");
-    LogKit::LogFormatted(LogKit::Low,"  Shift to top surface                     : %10.1f\n", model_settings->getTimeDTop());
+    if (model_settings->getTimeDTop() != RMISSING)
+      LogKit::LogFormatted(LogKit::Low,"  Shift to top surface                     : %10.1f\n", model_settings->getTimeDTop());
     LogKit::LogFormatted(LogKit::Low,"  Time slice                               : %10.1f\n", model_settings->getTimeLz());
     LogKit::LogFormatted(LogKit::Low,"  Sampling density                         : %10.1f\n", model_settings->getTimeDz());
     LogKit::LogFormatted(LogKit::Low,"  Number of layers                         : %10d\n",   int(model_settings->getTimeLz()/model_settings->getTimeDz()+0.5));

--- a/src/commondata.cpp
+++ b/src/commondata.cpp
@@ -3444,13 +3444,17 @@ CommonData::Process1DWavelet(const ModelSettings                        * model_
         const float lim_low   = 0.33f;
 
         // prescale, then we have correct size order, and later scale estimation will be ok.
-        // Estimate scale as default for Ricker wavelets, if scale is not given in the model file
-        if (model_settings->getEstimateGlobalWaveletScale(i_timelapse,j_angle) || (use_ricker_wavelet && model_settings->getWaveletScale(i_timelapse,j_angle) == 1.0)) {
+        if (model_settings->getEstimateGlobalWaveletScale(i_timelapse,j_angle)) {
           LogKit::LogFormatted(LogKit::Low,"  Wavelet is prescaled with estimated global scale (" + NRLib::ToString(prescale) + ").\n");
           wavelet->multiplyRAmpByConstant(prescale);
           wavelet->setPreScale(prescale);
         }
         else {
+
+          if  (use_ricker_wavelet && model_settings->getWaveletScale(i_timelapse,j_angle) == 1.0) {
+            LogKit::LogFormatted(LogKit::Warning,"\n Warning: Ricker wavelet is used without scale given in modelfile or scale estiamted with Crava.\n");
+            TaskList::addTask("Consider having Crava estimate scale for Ricker wavelet for angle no " + NRLib::ToString(j_angle) + ".\n");
+          }
 
           if (model_settings->getWaveletScale(i_timelapse,j_angle)!= 1.0f && (prescale>lim_high || prescale<lim_low)) {
             std::string text = "The wavelet given for angle no "+NRLib::ToString(j_angle)+" is badly scaled. Ask Crava to estimate global wavelet scale."

--- a/src/cravaresult.h
+++ b/src/cravaresult.h
@@ -110,10 +110,6 @@ public:
                           const std::string        & sub_dir,
                           const std::string        & base_name) const;
 
-  void WriteFilePostCovGrids(const ModelSettings * model_settings,
-                             const Simbox        & simbox,
-                             std::string           interval_name = "") const;
-
   void WriteBlockedWells(const std::map<std::string, BlockedLogsCommon *> & blocked_wells,
                          const ModelSettings                              * model_settings,
                          std::vector<std::string>                           facies_name,

--- a/src/cravaresult.h
+++ b/src/cravaresult.h
@@ -163,11 +163,6 @@ public:
                                           const NRLib::Matrix & reflection_matrix,
                                           int                   angle) const;
 
-  void GenerateSyntheticSeismicLogs(std::vector<Wavelet *>                     & wavelet,
-                                    std::map<std::string, BlockedLogsCommon *> & blocked_wells,
-                                    const NRLib::Matrix                        & reflection_matrix,
-                                    const Simbox                               & simbox);
-
   void GenerateWellOptSyntSeis(ModelSettings                              * model_settings,
                                CommonData                                 * common_data,
                                std::map<std::string, BlockedLogsCommon *> & blocked_wells,

--- a/src/parameteroutput.cpp
+++ b/src/parameteroutput.cpp
@@ -470,7 +470,9 @@ ParameterOutput::WriteFile(const ModelSettings     * model_settings,
         LogKit::LogFormatted(LogKit::Low," Writing SEGY file "+file_name_segy+"...");
 
         //Take nz from segy if output_dz = segy_dz, otherwise a nz is calculated
-        int nz_output = FindOutputSegyNz(output, model_settings, z0);
+        float output_dz = 0.0;
+        int output_nz   = 0;
+        FindOutputSegyDzNz(output, model_settings, z0, output_dz, output_nz);
 
         SegyGeometry geometry(simbox->getx0(), simbox->gety0(), simbox->getdx(), simbox->getdy(),
                               simbox->getnx(), simbox->getny(),simbox->getIL0(), simbox->getXL0(),
@@ -480,7 +482,8 @@ ParameterOutput::WriteFile(const ModelSettings     * model_settings,
         SegY * segy = new SegY(output,
                                &geometry,
                                z0,
-                               nz_output,
+                               output_dz,
+                               output_nz,
                                file_name_segy,
                                true, //Write to file
                                *thf,
@@ -648,9 +651,11 @@ ParameterOutput::WriteResampledStormCube(const StormContGrid * storm_grid,
     LogKit::LogFormatted(LogKit::Low," Writing SEGY file "+gf_name+"...");
 
     //Take nz from segy if output_dz = segy_dz, otherwise a nz is calculated
-    int nz_output = FindOutputSegyNz(outgrid, model_settings, z0);
+    float dz_output = 0.0;
+    int nz_output   = 0;
+    FindOutputSegyDzNz(outgrid, model_settings, z0, dz_output, nz_output);
 
-    SegY * segy = new SegY(outgrid, &geometry, z0, nz_output, gf_name, true);
+    SegY * segy = new SegY(outgrid, &geometry, z0, dz_output, nz_output, gf_name, true);
     delete segy;
     LogKit::LogFormatted(LogKit::Low,"done\n");
 
@@ -674,27 +679,31 @@ ParameterOutput::SeismicShift(NRLib::Grid<float> * grid)
   }
 }
 
-int
-ParameterOutput::FindOutputSegyNz(const StormContGrid * outgrid,
-                                  const ModelSettings * model_settings,
-                                  const double          z0)
+void
+ParameterOutput::FindOutputSegyDzNz(const StormContGrid * outgrid,
+                                    const ModelSettings * model_settings,
+                                    const double          z0,
+                                    float               & dz_output,
+                                    int                 & nz_output)
 {
   //If output grid and input segy have the same resolution (dz) we use nz from segy
-  float dz_output_r = float(floor((outgrid->GetLZ()/outgrid->GetNK())*10)/10);
-  float dz_input    = floor(model_settings->getSegyDz()*10)/10;
-  int nz_output;
+  float dz_output_r = static_cast<float>(floor(outgrid->GetLZ()/outgrid->GetNK()));
+  float dz_input    = floor(model_settings->getSegyDz());
 
   //We do not use nz from input segy if output offset is specified seperately in the model file
   if (dz_output_r == dz_input && model_settings->getMatchOutputInputSegy() == true) {
+    dz_output = floor(model_settings->getSegyDz());
     nz_output = model_settings->getSegyNz();
   }
   else {
+
     float dz_output = float(floor(outgrid->GetLZ()/outgrid->GetNK()));
 
     if (dz_output < 1.0)
       dz_output = 1.0;
-    nz_output       = int(ceil((outgrid->GetZMax() - z0)/dz_output));
+
+    nz_output = int(ceil((outgrid->GetZMax() - z0)/dz_output));
+
   }
 
-  return nz_output;
 }

--- a/src/parameteroutput.h
+++ b/src/parameteroutput.h
@@ -124,8 +124,10 @@ private:
 
   static void     SeismicShift(NRLib::Grid<float> * grid);
 
-  static int FindOutputSegyNz(const StormContGrid * outgrid,
-                       const ModelSettings * model_settings,
-                       const double          z0);
+  static void FindOutputSegyDzNz(const StormContGrid * outgrid,
+                                 const ModelSettings * model_settings,
+                                 const double          z0,
+                                 float               & dz_output,
+                                 int               & nz_output);
 };
 #endif

--- a/src/xmlmodelfile.cpp
+++ b/src/xmlmodelfile.cpp
@@ -981,6 +981,7 @@ XmlModelFile::parseWavelet(TiXmlNode * node, std::string & errTxt)
   std::string value;
   bool        estimate = false;
   float       peakFrequency;
+  bool        use_ricker = false;
 
   if (parseFileName(root, "file-name", value, errTxt) == true) {
     inputFiles_->addWaveletFile(value);
@@ -993,6 +994,7 @@ XmlModelFile::parseWavelet(TiXmlNode * node, std::string & errTxt)
     modelSettings_->addEstimateWavelet(false);
     modelSettings_->addUseRickerWavelet(true);
     modelSettings_->addRickerPeakFrequency(peakFrequency);
+    use_ricker = true;
   }
   else {
     inputFiles_->addWaveletFile(""); //Keeping tables balanced.
@@ -1019,8 +1021,15 @@ XmlModelFile::parseWavelet(TiXmlNode * node, std::string & errTxt)
   if(parseBool(root, "estimate-scale",estimate,tmpErr) == false || tmpErr != "") {
    if(scaleGiven==false) // no commands given
    {
-    modelSettings_->addWaveletScale(1);
-    modelSettings_->addEstimateGlobalWaveletScale(false);
+     //Estimate scale default true for Ricker
+     if (use_ricker == true) {
+       modelSettings_->addEstimateGlobalWaveletScale(true);
+       modelSettings_->addWaveletScale(1);
+     }
+     else {
+       modelSettings_->addWaveletScale(1);
+       modelSettings_->addEstimateGlobalWaveletScale(false);
+     }
    }
     errTxt += tmpErr;
   }
@@ -1039,6 +1048,10 @@ XmlModelFile::parseWavelet(TiXmlNode * node, std::string & errTxt)
     {
       modelSettings_->addWaveletScale(1);
       modelSettings_->addEstimateGlobalWaveletScale(false);
+
+      if (use_ricker == true)
+        LogKit::LogFormatted(LogKit::Warning, "\nWARNING: Scale should be given or estimated with Ricker wavelets, but estimate-scale is set to \'no\'.\n\n");
+
     }
 
 


### PR DESCRIPTION
-Fixed issue with use of dz when we match output segy with input segy. dz is now handled outside in FindOutputSegyDzNz.
-Fixed issue where merged correlation grids were rewritten per interval for multizone
-Added that ricker wavelets will always estiamte scale if scale is not given in modelfile