### PR TITLE
CRA-862: Use segy dz when creating output simbox

### DIFF
--- a/libs/nrlib/surface/surfaceio.hpp
+++ b/libs/nrlib/surface/surfaceio.hpp
@@ -728,11 +728,11 @@ void NRLib::CreateSurfaceFromILXL(RegularSurface<A>   & surface,
   //We require the surfaces to have even sampling
   for (int i = 1; i < static_cast<int>(il_vec_sorted.size()); i++)
     if ((il_vec_sorted[i] - il_vec_sorted[i-1]) != d_il_file)
-        throw Exception("Found inconsistencies in the surface sampling. Has the surface even sampling?\n");
+        throw Exception("Found inconsistencies in the surface sampling. Does the surface have uneven/irregular sampling? Crava requires regular XYZ/Multicolumn Ascii-surfaces\n");
 
   for (int i = 1; i < static_cast<int>(xl_vec_sorted.size()); i++)
     if ((xl_vec_sorted[i] - xl_vec_sorted[i-1]) != d_xl_file)
-        throw Exception("Found inconsistencies in the surface sampling. Has the surface even sampling?\n");
+        throw Exception("Found inconsistencies in the surface sampling. Does the surface have uneven/irregular sampling? Crava requires regular XYZ/Multicolumn Ascii-surfaces\n");
 
   for (int k = 0; k < n; k++) {
     //Local IL/XL

--- a/src/commondata.h
+++ b/src/commondata.h
@@ -420,7 +420,7 @@ private:
                                        MultiIntervalGrid  * multi_interval_grid,
                                        std::string        & err_text);
 
-  double             FindDzMin(MultiIntervalGrid * multi_interval_grid);
+  double             FindDzMin(MultiIntervalGrid * multi_interval_grid, ModelSettings * model_settings);
 
   void               WriteAreas(const SegyGeometry  * area_params,
                                 Simbox              * time_simbox,


### PR DESCRIPTION
If number of layers is omitted for an interval we now use input segy dz for each interval when finding dz for output grid/simbox. Previously we went from input segy dz to number of layers (internally) and then back to dz.