### PR TITLE
CRA-869: Fixed issue with segmentation fault for output segy.

### DIFF
--- a/src/parameteroutput.cpp
+++ b/src/parameteroutput.cpp
@@ -700,7 +700,7 @@ ParameterOutput::FindOutputSegyDzNz(const StormContGrid * outgrid,
   }
   else {
 
-    float dz_output = float(floor(outgrid->GetLZ()/outgrid->GetNK()));
+    dz_output = float(floor(outgrid->GetLZ()/outgrid->GetNK()));
 
     if (dz_output < 1.0)
       dz_output = 1.0;


### PR DESCRIPTION
Issue with dz value being reset when writing segy output (seen if we activated segy output from test case 1).