### PR TITLE
CRA-880: Changed constant surfaces from 2x2 to seismic resolution.

### DIFF
--- a/src/background.h
+++ b/src/background.h
@@ -52,7 +52,8 @@ public:
   void         ResampleParameter(NRLib::Grid<float> *& p_new, // Resample to
                                  NRLib::Grid<float> *  p_old, // Resample from
                                  const Simbox       *  simbox_new,
-                                 const Simbox       *  simbox_old);
+                                 const Simbox       *  simbox_old,
+                                 std::string         & err_text);
 
 
 private:
@@ -74,7 +75,8 @@ private:
                                        NRLib::Grid<float>  * & bg_vs,
                                        NRLib::Grid<float>  * & bg_rho,
                                        const Simbox        *   bg_simbox,
-                                       const Simbox        *   simbox);
+                                       const Simbox        *   simbox,
+                                       std::string           & err_text);
   static
   void         CalculateBackgroundTrend(std::vector<double>               & trend,
                                         std::vector<double>               & avgDev,

--- a/src/commondata.h
+++ b/src/commondata.h
@@ -934,7 +934,8 @@ private:
                                                    int            output_format,
                                                    int            output_domain,
                                                    int            other_output,
-                                                   std::string    interval_name) const;
+                                                   std::string    interval_name,
+                                                   std::string  & err_text) const;
 
   void               SetupExtendedBackgroundSimbox(const Simbox * simbox,
                                                    Surface      * top_corr_surf,
@@ -943,7 +944,8 @@ private:
                                                    int            output_format,
                                                    int            output_domain,
                                                    int            other_output,
-                                                   std::string    interval_name) const;
+                                                   std::string    interval_name,
+                                                   std::string  & err_text) const;
 
   bool               SetupPriorCorrelation(const ModelSettings                                              * model_settings,
                                            const InputFiles                                                 * input_files,

--- a/src/cravaresult.cpp
+++ b/src/cravaresult.cpp
@@ -855,7 +855,14 @@ CravaResult::CombineVerticalTrends(MultiIntervalGrid                         * m
 
       NRLib::Grid<float> * trend_grid_extended = new NRLib::Grid<float>(nx, ny, nz_extended);
       Background::FillInVerticalTrend(trend_grid_extended, vertical_trend(i,0));
-      Background::ResampleParameter(trend_grid, trend_grid_extended, interval_simbox, bg_simbox);
+
+      std::string err_text = "";
+      Background::ResampleParameter(trend_grid, trend_grid_extended, interval_simbox, bg_simbox, err_text);
+
+      if (err_text != "")
+        LogKit::LogFormatted(LogKit::Error,"\n Problem combining vertical trends\n: " + err_text);
+
+
       delete trend_grid_extended;
 
     }
@@ -883,7 +890,13 @@ CravaResult::CombineVerticalTrends(MultiIntervalGrid                         * m
 
       NRLib::Grid<float> * trend_grid_extended = new NRLib::Grid<float>(nx, ny, nz_extended);
       Background::FillInVerticalTrend(trend_grid_extended, vertical_trend(i,1));
-      Background::ResampleParameter(trend_grid, trend_grid_extended, interval_simbox, bg_simbox);
+
+      std::string err_text = "";
+      Background::ResampleParameter(trend_grid, trend_grid_extended, interval_simbox, bg_simbox, err_text);
+
+      if (err_text != "")
+        LogKit::LogFormatted(LogKit::Error,"\n Problem combining vertical trends\n: " + err_text);
+
       delete trend_grid_extended;
 
     }
@@ -911,7 +924,12 @@ CravaResult::CombineVerticalTrends(MultiIntervalGrid                         * m
 
       NRLib::Grid<float> * trend_grid_extended = new NRLib::Grid<float>(nx, ny, nz_extended);
       Background::FillInVerticalTrend(trend_grid_extended, vertical_trend(i,2));
-      Background::ResampleParameter(trend_grid, trend_grid_extended, interval_simbox, bg_simbox);
+
+      std::string err_text = "";
+      Background::ResampleParameter(trend_grid, trend_grid_extended, interval_simbox, bg_simbox, err_text);
+
+      if (err_text != "")
+        LogKit::LogFormatted(LogKit::Error,"\n Problem combining vertical trends\n: " + err_text);
       delete trend_grid_extended;
 
     }

--- a/src/multiintervalgrid.cpp
+++ b/src/multiintervalgrid.cpp
@@ -61,6 +61,7 @@ MultiIntervalGrid::MultiIntervalGrid(ModelSettings * model_settings,
       uncertainties_[0] = 0;
 
       top_surface = MakeSurfaceFromFileName(top_surface_file_name_temp, *estimation_simbox, model_settings, input_files, segy_geometry, err_text);
+
       surfaces[0] = *top_surface;
       for (int i = 0; i < n_intervals_; i++) {
 
@@ -635,10 +636,12 @@ Surface * MultiIntervalGrid::MakeSurfaceFromFileName(const std::string   & file_
     InterpolateMissing(new_surface);
   }
   else { //If the file name is a value
-
-    //Create a constant surface that follows the seismic data
+    //18.10.17 Changed from using 2*2 to nx*ny due to a problem with constant correlation surfaces (see CRA-880):
+    //When we expand simboxes we use the correlation surfaces and add/subtract top/bot surfaces, if the correlation surface only have 4
+    // points then we may get undesired results when adding/subtracting a full surface.
+    // Ideally all surfaces used in Crava should have the same resolution
     new_surface = new Surface(estimation_simbox.getx0(), estimation_simbox.gety0(), estimation_simbox.getlx(), estimation_simbox.getly(),
-                              2, 2, estimation_simbox.getAngle(), atof(file_name.c_str()));
+                              estimation_simbox.getnx(), estimation_simbox.getny(), estimation_simbox.getAngle(), atof(file_name.c_str()));
   }
 
   return new_surface;

--- a/src/wavelet1D.h
+++ b/src/wavelet1D.h
@@ -18,6 +18,7 @@ class Wavelet1D : public Wavelet {
 public:
 //Constructors and destructor
   Wavelet1D();
+
   Wavelet1D(const Simbox                                     * simbox,
             SeismicStorage                                   * seismic_data,
             std::map<std::string, BlockedLogsCommon *>       & mapped_blocked_logs,
@@ -37,6 +38,7 @@ public:
             float               theta,
             int               & errCode,
             std::string       & errText);
+
   Wavelet1D(Wavelet * wavelet);
 
   Wavelet1D(std::vector<float>   vec,
@@ -55,11 +57,11 @@ public:
           int                 nz,
           int                 nzp);
 
-Wavelet1D(const ModelSettings * modelSettings,
-          const float         * reflCoef,
-          float                 theta,
-          float                 peakFrequency,
-          int                 & errCode);
+  Wavelet1D(const ModelSettings * modelSettings,
+            const float         * reflCoef,
+            float                 theta,
+            float                 peakFrequency,
+            int                 & errCode);
 
   void   shiftAndScale(float shift, float scale);
   void   adjustForAmplitudeEffect(double multiplyer, double Halpha);


### PR DESCRIPTION
There was a bug estimating the extended background simbox (CRA-880), this was due to using constant surfaces. These constant surfaces was only 2x2 and the problem was when this surface was subtracted from a surface read from file with millions of points.
The solution was to instead create constant surfaces in Crava having the seismic resolution.

This is related to git issue 255.